### PR TITLE
send mouse report only if x, y or wheel value is not 0

### DIFF
--- a/STM32F1/cores/maple/usb_hid_device.cpp
+++ b/STM32F1/cores/maple/usb_hid_device.cpp
@@ -77,6 +77,7 @@ void HIDMouse::click(uint8_t b)
 
 void HIDMouse::move(signed char x, signed char y, signed char wheel)
 {
+	if ((x != 0) || (y != 0) || (wheel != 0)){ /* send mouse report only if x,y or wheel value is not 0 */
 	uint8_t m[4];
 	m[0] = _buttons;
 	m[1] = x;
@@ -96,6 +97,7 @@ void HIDMouse::move(signed char x, signed char y, signed char wheel)
     }
 	/* flush out to avoid having the pc wait for more data */
 	usb_hid_tx(NULL, 0);
+	}
 }
 
 void HIDMouse::buttons(uint8_t b)


### PR DESCRIPTION
USB HID requires reports from USB mouse only if movement (x, y or scroll) was detected
