### PR TITLE
USB HID and Midi support for generic STM32F103C boards

### DIFF
--- a/STM32F1/boards.txt
+++ b/STM32F1/boards.txt
@@ -207,6 +207,14 @@ genericSTM32F103C.menu.upload_method.BMPMethod.upload.protocol=gdb_bmp
 genericSTM32F103C.menu.upload_method.BMPMethod.upload.tool=bmp_upload
 genericSTM32F103C.menu.upload_method.BMPMethod.build.upload_flags=-DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG
 
+#--USB
+genericSTM32F103C.menu.usb.serial=Serial
+genericSTM32F103C.menu.usb.serial.build.usbtype=USB_SERIAL
+genericSTM32F103C.menu.usb.hid=Keyboard + Mouse + Joystick
+genericSTM32F103C.menu.usb.hid.build.usbtype=USB_HID
+genericSTM32F103C.menu.usb.midi=MIDI
+genericSTM32F103C.menu.usb.midi.build.usbtype=USB_MIDI
+
 
 ########################### Generic STM32F103R  ###########################
 

--- a/STM32F1/cores/maple/usb_hid_device.cpp
+++ b/STM32F1/cores/maple/usb_hid_device.cpp
@@ -77,6 +77,7 @@ void HIDMouse::click(uint8_t b)
 
 void HIDMouse::move(signed char x, signed char y, signed char wheel)
 {
+	if ((x != 0) || (y != 0) || (wheel != 0)){ /* send mouse report only if x,y or wheel value is not 0 */
 	uint8_t m[4];
 	m[0] = _buttons;
 	m[1] = x;
@@ -96,6 +97,7 @@ void HIDMouse::move(signed char x, signed char y, signed char wheel)
     }
 	/* flush out to avoid having the pc wait for more data */
 	usb_hid_tx(NULL, 0);
+	}
 }
 
 void HIDMouse::buttons(uint8_t b)

--- a/STM32F1/cores/maple/usb_hid_device.cpp
+++ b/STM32F1/cores/maple/usb_hid_device.cpp
@@ -77,7 +77,6 @@ void HIDMouse::click(uint8_t b)
 
 void HIDMouse::move(signed char x, signed char y, signed char wheel)
 {
-	if ((x != 0) || (y != 0) || (wheel != 0)){ /* send mouse report only if x,y or wheel value is not 0 */
 	uint8_t m[4];
 	m[0] = _buttons;
 	m[1] = x;
@@ -97,7 +96,6 @@ void HIDMouse::move(signed char x, signed char y, signed char wheel)
     }
 	/* flush out to avoid having the pc wait for more data */
 	usb_hid_tx(NULL, 0);
-	}
 }
 
 void HIDMouse::buttons(uint8_t b)

--- a/STM32F1/variants/generic_stm32f103c/wirish/boards_setup.cpp
+++ b/STM32F1/variants/generic_stm32f103c/wirish/boards_setup.cpp
@@ -42,6 +42,7 @@
 #include <boards.h>
 #include <usb_serial.h>
 #include <usb_hid_device.h>
+#include <usb_midi.h>
 
 // Allow boards to provide a PLL multiplier. This is useful for
 // e.g. STM32F100 value line MCUs, which use slower multipliers.
@@ -105,6 +106,18 @@ namespace wirish {
 #endif			
 			HID.begin();
 #endif
+#if  defined(SERIAL_USB) && defined(USB_MIDI)
+#ifdef GENERIC_BOOTLOADER			
+			//Reset the USB interface on generic boards - developed by Victor PV
+			gpio_set_mode(PIN_MAP[PA12].gpio_device, PIN_MAP[PA12].gpio_bit, GPIO_OUTPUT_PP);
+			gpio_write_bit(PIN_MAP[PA12].gpio_device, PIN_MAP[PA12].gpio_bit,0);
+			
+			for(volatile unsigned int i=0;i<256;i++);// Only small delay seems to be needed, and USB pins will get configured in Serial.begin
+			gpio_set_mode(PIN_MAP[PA12].gpio_device, PIN_MAP[PA12].gpio_bit, GPIO_INPUT_FLOATING);
+#endif		
+			MidiUSB.begin();
+#endif
+
 		}
 
         __weak void series_init(void) {

--- a/STM32F1/variants/generic_stm32f103c/wirish/boards_setup.cpp
+++ b/STM32F1/variants/generic_stm32f103c/wirish/boards_setup.cpp
@@ -41,6 +41,7 @@
 
 #include <boards.h>
 #include <usb_serial.h>
+#include <usb_hid_device.h>
 
 // Allow boards to provide a PLL multiplier. This is useful for
 // e.g. STM32F100 value line MCUs, which use slower multipliers.
@@ -80,7 +81,7 @@ namespace wirish {
         }
 
         __weak void board_setup_usb(void) {
-#ifdef SERIAL_USB
+#if defined(SERIAL_USB) && defined(USB_SERIAL)
 			
 #ifdef GENERIC_BOOTLOADER			
 			//Reset the USB interface on generic boards - developed by Victor PV
@@ -91,6 +92,18 @@ namespace wirish {
 			gpio_set_mode(PIN_MAP[PA12].gpio_device, PIN_MAP[PA12].gpio_bit, GPIO_INPUT_FLOATING);
 #endif			
 			Serial.begin();// Roger Clark. Changed SerialUSB to Serial for Arduino sketch compatibility
+#endif
+#if defined(SERIAL_USB) && defined(USB_HID)
+			
+#ifdef GENERIC_BOOTLOADER			
+			//Reset the USB interface on generic boards - developed by Victor PV
+			gpio_set_mode(PIN_MAP[PA12].gpio_device, PIN_MAP[PA12].gpio_bit, GPIO_OUTPUT_PP);
+			gpio_write_bit(PIN_MAP[PA12].gpio_device, PIN_MAP[PA12].gpio_bit,0);
+			
+			for(volatile unsigned int i=0;i<256;i++);// Only small delay seems to be needed, and USB pins will get configured in Serial.begin
+			gpio_set_mode(PIN_MAP[PA12].gpio_device, PIN_MAP[PA12].gpio_bit, GPIO_INPUT_FLOATING);
+#endif			
+			HID.begin();
 #endif
 		}
 


### PR DESCRIPTION
Tested using Blue Pill board, both with bootloader and without.
One issue in case of bootloader-less board: HID.begin() or MidiUSB.begin() must be called in setup() otherwise device is not properly enumerated, using Victor PV's usb reset (made for bootloader) doesn't help.
